### PR TITLE
Fix issue with UndoManager reporting two inputs when undo:ing deletes by flushing operation immediately

### DIFF
--- a/src/y-codemirror.js
+++ b/src/y-codemirror.js
@@ -66,6 +66,7 @@ const typeObserver = (binding, event) => {
     // if possible, bundle the changes using cm.operation
     if (cm) {
       cm.operation(performChange)
+      cm.endOperation()
     } else {
       performChange()
     }


### PR DESCRIPTION
Fixes issue #13 

I've run this in production for a week now and it looks like it's working fine. Haven't encountered any issue with it so I believe it's ready for a PR. :)