### PR TITLE
Fix issue with maintaining scrolled position when other clients update document

### DIFF
--- a/src/y-codemirror.js
+++ b/src/y-codemirror.js
@@ -74,7 +74,7 @@ const typeObserver = (binding, event) => {
       head = anchor
       anchor = tmp
     }
-    cm.setSelection(cm.posFromIndex(anchor), cm.posFromIndex(head))
+    cm.setSelection(cm.posFromIndex(anchor), cm.posFromIndex(head), { scroll: false })
   })
 }
 


### PR DESCRIPTION
This PR fixes an issue where if you have a large document and place your cursor at the top of the document, scroll down a bit (without changing cursor selection), and another connected client updates the doc you'd get automatically scolled to your cursor instead of staying where you've scrolled.

Maybe this is intended behaviour but I doubt it. If the user has manually scrolled somewhere they would expect to stay there even if someone else is updating the document.