### PR TITLE
Force undo manager to stop capture when pasting

### DIFF
--- a/src/y-codemirror.js
+++ b/src/y-codemirror.js
@@ -81,6 +81,11 @@ const typeObserver = (binding, event) => {
 const targetObserver = (binding, changes) => {
   binding._mux(() => {
     binding.doc.transact(() => {
+      const hasPaste = binding.yUndoManager && changes.some(change => change.origin === 'paste');
+      if (hasPaste) {
+        binding.yUndoManager.stopCapturing();
+      }
+
       if (changes.length > 1) {
         // If there are several consecutive changes, we can't reliably compute the positions anymore. See y-codemirror#11
         // Instead, we will compute the diff and apply the changes
@@ -97,6 +102,10 @@ const targetObserver = (binding, changes) => {
         if (change.text.length > 0) {
           binding.type.insert(start, change.text.join('\n'))
         }
+      }
+
+      if (hasPaste) {
+        binding.yUndoManager.stopCapturing();
       }
     }, binding)
   })


### PR DESCRIPTION
This was raised in https://github.com/jupyterlab/jupyterlab/issues/10928

The capture seems to be stopped before capturing the paste event. But the second stop capture statement is not working because I succeed to do undo's that removed characters typed after the paste change.