### PR TITLE
Improve remote user's cursor

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -7,15 +7,12 @@
     <style>
       .remote-caret {
         position: relative;
-        border-left: 2px solid black;
-        margin-left: -1px;
-        margin-right: -1px;
+        width: 2px;
         box-sizing: border-box;
       }
       .remote-caret > div {
         white-space: nowrap;
         position: absolute;
-        top: -1.05em;
         left: -2px;
         font-size: .6em;
         background-color: rgb(250, 129, 0);

--- a/src/y-codemirror.js
+++ b/src/y-codemirror.js
@@ -154,6 +154,13 @@ const createRemoteCaret = (username, color, cursorCoords) => {
   return caret
 }
 
+const updateCaret = (caret, username, color) => {
+  const userDiv = caret.firstChild;
+  caret.style.backgroundColor = color;
+  userDiv.style.backgroundColor = color;
+  userDiv.innerText = username;
+}
+
 function setCaretPosition(caret, cursorCoords, cm) {
   if (!caret) return;
 
@@ -171,7 +178,8 @@ function setCaretPosition(caret, cursorCoords, cm) {
   const hideTimer = caret.hideTimer;
   if (hideTimer) {
     clearTimeout(hideTimer);
-  } else {
+  }
+  if (caret.classList.contains('hide-name')) {
     caret.classList.remove('hide-name');
   }
 
@@ -268,6 +276,7 @@ const updateRemoteSelection = (y, cm, type, cursors, clientId, awareness) => {
         caretEl = createRemoteCaret(user.name, user.color, cursorCoords);
         cm.addWidget({line: 0, ch: 0}, caretEl, false)
       }
+      updateCaret(caretEl, user.name, user.color);
       setCaretPosition(caretEl, cursorCoords, cm);
     }
     cursors.set(clientId, { caret: caretEl, sel, awCursor: cursor, headpos })

--- a/src/y-codemirror.js
+++ b/src/y-codemirror.js
@@ -170,7 +170,7 @@ function setCaretPosition(caret, cursorCoords, cm) {
   const distanceFromTop = caret.offsetTop - cm.getScrollInfo().top;
   const userDiv = caret.firstChild;
   if (distanceFromTop - userDiv.offsetHeight <= 4) {
-    userDiv.style.top = `${userDiv.offsetHeight - 5}px`;
+    userDiv.style.top = `${userDiv.offsetHeight}px`;
   } else {
     userDiv.style.top = `-${userDiv.offsetHeight}px`;
   }


### PR DESCRIPTION
There are two issues with remote caret.
1. When remote user's cursor is on the first line, their name inside tooltip is cut off. The tooltip doesn't automatically repositions itself when there isn't enough vertical space.

https://user-images.githubusercontent.com/23213686/177056669-081ebc6c-a87f-453e-82b0-31bf3c803b40.mov


2. Remote user's cursor tooltip is not shown when they are typing. It's only shown when the cursor is actually moved.

https://user-images.githubusercontent.com/23213686/177056781-2992046e-8c25-4ee9-8e8e-e24cba3d9d6c.mov



Since currently, we store relative position for cursors, awareness doesn't get updated when the cursor is moved while typing. This causes the second issue. To fix that, I've refactored the code to also save `Codemirror.Position` information inside `cursors` set in `headpos` key. And any time doc's state changes, we compare the before and after `headpos`, and update the position accordingly. 
I've used `cm.addWidget` instead of `cm.setBookmark` (as done previously) because bookmarks are inserted as children to `.Codemirror-line` node. However, all `.Codemirror-line` nodes have `z-index: 2`. This causes the DOM node that occurs first in the DOM tree to have a higher stacking context. This means, when we position tooltip to be below the current line, it'll appear behind the next line.


<b>Demo</b>

https://user-images.githubusercontent.com/23213686/177056956-bc926761-4ba6-47d5-8fcb-b354d507d024.mov



<b>Known Issue</b>
Because we only store relative position of cursors, and because in `typeObserver` function we don't really know which user made that change, we rely on comparing before and after `headpos`. This however has its limitations. Consider the scenario where user A and user B are collaborating. The text is `1234`. A's cursor is between 3 and 4. Now, B inserts something before `1`. Then, A's tooltip will be shown to B, even though A has not typed anything. This is because when users are collaborating on the same line, then any changes to that line will also change `ch` key of `headpos`.